### PR TITLE
fix: add support for zita-convolver 4

### DIFF
--- a/source/fconfig.cc
+++ b/source/fconfig.cc
@@ -60,8 +60,8 @@ int convnew (const char *line, int lnum)
     while ((fragm > Convproc::MINPART) && (fragm >= 2 * size)) fragm /= 2;
 
     convproc->set_options (options);
-    convproc->set_density (dens);
-    if (convproc->configure (ninp, nout, size, fragm, fragm, fragm))
+    // convproc->set_density (dens);
+    if (convproc->configure (ninp, nout, size, fragm, fragm, fragm, dens))
     {   
         fprintf (stderr, "Can't initialise convolution engine\n");
         return ERR_OTHER;

--- a/source/fconfig.cc
+++ b/source/fconfig.cc
@@ -24,6 +24,16 @@
 #include <string.h>
 #include "config.h"
 
+#define ZITA_CONVOLVER_VERSION  0
+#if ZITA_CONVOLVER_MAJOR_VERSION == 3
+#undef ZITA_CONVOLVER_VERSION
+#define ZITA_CONVOLVER_VERSION  3
+#elif ZITA_CONVOLVER_MAJOR_VERSION == 4
+#undef ZITA_CONVOLVER_VERSION
+#define ZITA_CONVOLVER_VERSION  4
+#else
+#error "This version of IR requires zita-convolver 3.x.x or 4.x.x"
+#endif
 
 int convnew (const char *line, int lnum)
 {
@@ -60,13 +70,20 @@ int convnew (const char *line, int lnum)
     while ((fragm > Convproc::MINPART) && (fragm >= 2 * size)) fragm /= 2;
 
     convproc->set_options (options);
-    // convproc->set_density (dens);
+#if ZITA_CONVOLVER_VERSION == 3
+    convproc->set_density (dens);
+    if (convproc->configure (ninp, nout, size, fragm, fragm, fragm))
+    {   
+        fprintf (stderr, "Can't initialise convolution engine\n");
+        return ERR_OTHER;
+    }
+#elif ZITA_CONVOLVER_VERSION == 4
     if (convproc->configure (ninp, nout, size, fragm, fragm, fragm, dens))
     {   
         fprintf (stderr, "Can't initialise convolution engine\n");
         return ERR_OTHER;
     }
-
+#endif
     return 0;
 }
 

--- a/source/jconfig.cc
+++ b/source/jconfig.cc
@@ -25,7 +25,6 @@
 #include "jclient.h"
 #include "config.h"
 
-
 extern Jclient     *jclient;
 extern unsigned int fragm;
 
@@ -88,8 +87,9 @@ int convnew (const char *line, int lnum)
     }
 
     convproc->set_options (options);
-    convproc->set_density (dens);
-    if (convproc->configure (ninp, nout, size, fragm, part, Convproc::MAXPART))
+
+    // convproc->set_density (dens);
+    if (convproc->configure (ninp, nout, size, fragm, part, Convproc::MAXPART, dens))
     {   
         fprintf (stderr, "Can't initialise convolution engine.\n");
         return ERR_OTHER;

--- a/source/jconfig.cc
+++ b/source/jconfig.cc
@@ -25,6 +25,17 @@
 #include "jclient.h"
 #include "config.h"
 
+#define ZITA_CONVOLVER_VERSION  0
+#if ZITA_CONVOLVER_MAJOR_VERSION == 3
+#undef ZITA_CONVOLVER_VERSION
+#define ZITA_CONVOLVER_VERSION  3
+#elif ZITA_CONVOLVER_MAJOR_VERSION == 4
+#undef ZITA_CONVOLVER_VERSION
+#define ZITA_CONVOLVER_VERSION  4
+#else
+#error "This version of IR requires zita-convolver 3.x.x or 4.x.x"
+#endif
+
 extern Jclient     *jclient;
 extern unsigned int fragm;
 
@@ -88,7 +99,16 @@ int convnew (const char *line, int lnum)
 
     convproc->set_options (options);
 
-    // convproc->set_density (dens);
+#if ZITA_CONVOLVER_VERSION == 3
+    convproc->set_density (dens);
+    if (convproc->configure (ninp, nout, size, fragm, part, Convproc::MAXPART))
+    {   
+        fprintf (stderr, "Can't initialise convolution engine.\n");
+        return ERR_OTHER;
+    }
+
+    return 0;
+#elif ZITA_CONVOLVER_VERSION == 4
     if (convproc->configure (ninp, nout, size, fragm, part, Convproc::MAXPART, dens))
     {   
         fprintf (stderr, "Can't initialise convolution engine.\n");
@@ -96,8 +116,8 @@ int convnew (const char *line, int lnum)
     }
 
     return 0;
+#endif
 }
-
 
 int inpname (const char *line)
 {


### PR DESCRIPTION
I don't actually now what's going on here, I just found that this doesn't compile on my machine. After this I found that the problem is in the updated zita-convolver library(?). So yeah, fixed it. Maybe it can be done better.